### PR TITLE
Do not close syslog on exit

### DIFF
--- a/node-syslog.js
+++ b/node-syslog.js
@@ -53,12 +53,3 @@ LOG_NOTICE		: 5,
 LOG_INFO		: 6,
 LOG_DEBUG		: 7
 };
-
-/*
- * Attach destroy handling
- *
- * XXX(sam) consider using AtExit: joyent/node#e4a8d261
- */
-process.on('exit', function() {
-	SyslogWrapper.close();
-});


### PR DESCRIPTION
It is not required to call `closelog()` before process exit, and doing
so makes it difficult for other exit handlers to log to syslog during
shutdown.

Fixes schamane/node-syslog#38
